### PR TITLE
Py3 Fix: non-str Validation Error

### DIFF
--- a/ckanext/usmetadata/plugin/helper.py
+++ b/ckanext/usmetadata/plugin/helper.py
@@ -20,7 +20,9 @@ def public_access_level_validator(regex_candidate):
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
         return p.toolkit.Invalid("Doesn't match public access level validators.")
-    return p.toolkit.Invalid("Can't parse Regex")
+
+    # The regex_candidate already has validation errors, so just pass the errors through
+    return regex_candidate
 
 
 def bureau_code_validator(regex_candidate):
@@ -29,7 +31,9 @@ def bureau_code_validator(regex_candidate):
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
         return p.toolkit.Invalid("Doesn't match bureau code format.")
-    return p.toolkit.Invalid("Can't parse Regex")
+
+    # The regex_candidate already has validation errors, so just pass the errors through
+    return regex_candidate
 
 
 def program_code_validator(regex_candidate):
@@ -38,7 +42,9 @@ def program_code_validator(regex_candidate):
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
         return p.toolkit.Invalid("Doesn't match program code format.")
-    return p.toolkit.Invalid("Can't parse Regex")
+
+    # The regex_candidate already has validation errors, so just pass the errors through
+    return regex_candidate
 
 
 def temporal_validator(regex_candidate):
@@ -47,7 +53,9 @@ def temporal_validator(regex_candidate):
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
         return p.toolkit.Invalid("Doesn't match temporal format.")
-    return p.toolkit.Invalid("Can't parse Regex")
+
+    # The regex_candidate already has validation errors, so just pass the errors through
+    return regex_candidate
 
 
 def release_date_validator(regex_candidate):
@@ -60,7 +68,9 @@ def release_date_validator(regex_candidate):
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
         return p.toolkit.Invalid("Doesn't match release date format.")
-    return p.toolkit.Invalid("Can't parse Regex")
+
+    # The regex_candidate already has validation errors, so just pass the errors through
+    return regex_candidate
 
 
 def accrual_periodicity_validator(regex_candidate):
@@ -76,7 +86,9 @@ def accrual_periodicity_validator(regex_candidate):
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
         return p.toolkit.Invalid("Doesn't match accrual periodicity format.")
-    return p.toolkit.Invalid("Can't parse Regex")
+
+    # The regex_candidate already has validation errors, so just pass the errors through
+    return regex_candidate
 
 
 def language_validator(regex_candidate):
@@ -92,7 +104,9 @@ def language_validator(regex_candidate):
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
         return p.toolkit.Invalid("Doesn't match language format.")
-    return p.toolkit.Invalid("Can't parse Regex")
+
+    # The regex_candidate already has validation errors, so just pass the errors through
+    return regex_candidate
 
 
 def primary_it_investment_uii_validator(regex_candidate):
@@ -101,7 +115,9 @@ def primary_it_investment_uii_validator(regex_candidate):
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
         return p.toolkit.Invalid("Doesn't match primary it investment uii format.")
-    return p.toolkit.Invalid("Can't parse Regex")
+
+    # The regex_candidate already has validation errors, so just pass the errors through
+    return regex_candidate
 
 
 def string_length_validator(max=100):

--- a/ckanext/usmetadata/plugin/helper.py
+++ b/ckanext/usmetadata/plugin/helper.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
+
+# 'str' function for py2 throws an error since it's different than py3
+old_str = str
 from builtins import str
+
 import copy
 from logging import getLogger
 import re
@@ -15,7 +19,7 @@ REDACTION_STROKE_REGEX = re.compile(
 
 
 def public_access_level_validator(regex_candidate):
-    if type(regex_candidate) == str:
+    if type(regex_candidate) in [str, old_str]:
         validator = re.compile(r'^(public)|(restricted public)|(non-public)$')
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
@@ -26,7 +30,7 @@ def public_access_level_validator(regex_candidate):
 
 
 def bureau_code_validator(regex_candidate):
-    if type(regex_candidate) == str:
+    if type(regex_candidate) in [str, old_str]:
         validator = re.compile(r'^\d{3}:\d{2}(\s*,\s*\d{3}:\d{2}\s*)*$')
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
@@ -37,7 +41,7 @@ def bureau_code_validator(regex_candidate):
 
 
 def program_code_validator(regex_candidate):
-    if type(regex_candidate) == str:
+    if type(regex_candidate) in [str, old_str]:
         validator = re.compile(r'^\d{3}:\d{3}(\s*,\s*\d{3}:\d{3}\s*)*$')
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
@@ -48,7 +52,7 @@ def program_code_validator(regex_candidate):
 
 
 def temporal_validator(regex_candidate):
-    if type(regex_candidate) == str:
+    if type(regex_candidate) in [str, old_str]:
         validator = re.compile(r'^([\-\dTWRZP/YMWDHMS:\+]{3,}/[\-\dTWRZP/YMWDHMS:\+]{3,})|(\[\[REDACTED).*?(\]\])$')
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate
@@ -59,7 +63,7 @@ def temporal_validator(regex_candidate):
 
 
 def release_date_validator(regex_candidate):
-    if type(regex_candidate) == str:
+    if type(regex_candidate) in [str, old_str]:
         validator = re.compile(
             r'^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?'
             r'|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]'
@@ -74,7 +78,7 @@ def release_date_validator(regex_candidate):
 
 
 def accrual_periodicity_validator(regex_candidate):
-    if type(regex_candidate) == str:
+    if type(regex_candidate) in [str, old_str]:
         validator = re.compile(
             r'^([Dd]ecennial)|([Qq]uadrennial)|([Aa]nnual)|([Bb]imonthly)|([Ss]emiweekly)|([Dd]aily)|([Bb]iweekly)'
             r'|([Ss]emiannual)|([Bb]iennial)|([Tt]riennial)|([Tt]hree times a week)|([Tt]hree times a month)'
@@ -92,7 +96,7 @@ def accrual_periodicity_validator(regex_candidate):
 
 
 def language_validator(regex_candidate):
-    if type(regex_candidate) == str:
+    if type(regex_candidate) in [str, old_str]:
         validator = re.compile(
             r'^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?'
             r'(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z]'
@@ -110,7 +114,7 @@ def language_validator(regex_candidate):
 
 
 def primary_it_investment_uii_validator(regex_candidate):
-    if type(regex_candidate) == str:
+    if type(regex_candidate) in [str, old_str]:
         validator = re.compile(r'^([0-9]{3}-[0-9]{9})|(\[\[REDACTED).*?(\]\])$')
         if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
             return regex_candidate

--- a/ckanext/usmetadata/plugin/helper.py
+++ b/ckanext/usmetadata/plugin/helper.py
@@ -22,10 +22,12 @@ def public_access_level_validator(regex_candidate):
 
 
 def bureau_code_validator(regex_candidate):
-    validator = re.compile(r'^\d{3}:\d{2}(\s*,\s*\d{3}:\d{2}\s*)*$')
-    if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
-        return regex_candidate
-    return p.toolkit.Invalid("Doesn't match bureau code format.")
+    if type(regex_candidate) == str:
+        validator = re.compile(r'^\d{3}:\d{2}(\s*,\s*\d{3}:\d{2}\s*)*$')
+        if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
+            return regex_candidate
+        return p.toolkit.Invalid("Doesn't match bureau code format.")
+    return p.toolkit.Invalid("Can't parse Regex")
 
 
 def program_code_validator(regex_candidate):

--- a/ckanext/usmetadata/plugin/helper.py
+++ b/ckanext/usmetadata/plugin/helper.py
@@ -15,10 +15,12 @@ REDACTION_STROKE_REGEX = re.compile(
 
 
 def public_access_level_validator(regex_candidate):
-    validator = re.compile(r'^(public)|(restricted public)|(non-public)$')
-    if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
-        return regex_candidate
-    return p.toolkit.Invalid("Doesn't match public access level validators.")
+    if type(regex_candidate) == str:
+        validator = re.compile(r'^(public)|(restricted public)|(non-public)$')
+        if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
+            return regex_candidate
+        return p.toolkit.Invalid("Doesn't match public access level validators.")
+    return p.toolkit.Invalid("Can't parse Regex")
 
 
 def bureau_code_validator(regex_candidate):
@@ -31,63 +33,75 @@ def bureau_code_validator(regex_candidate):
 
 
 def program_code_validator(regex_candidate):
-    validator = re.compile(r'^\d{3}:\d{3}(\s*,\s*\d{3}:\d{3}\s*)*$')
-    if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
-        return regex_candidate
-    return p.toolkit.Invalid("Doesn't match program code format.")
+    if type(regex_candidate) == str:
+        validator = re.compile(r'^\d{3}:\d{3}(\s*,\s*\d{3}:\d{3}\s*)*$')
+        if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
+            return regex_candidate
+        return p.toolkit.Invalid("Doesn't match program code format.")
+    return p.toolkit.Invalid("Can't parse Regex")
 
 
 def temporal_validator(regex_candidate):
-    validator = re.compile(r'^([\-\dTWRZP/YMWDHMS:\+]{3,}/[\-\dTWRZP/YMWDHMS:\+]{3,})|(\[\[REDACTED).*?(\]\])$')
-    if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
-        return regex_candidate
-    return p.toolkit.Invalid("Doesn't match temporal format.")
+    if type(regex_candidate) == str:
+        validator = re.compile(r'^([\-\dTWRZP/YMWDHMS:\+]{3,}/[\-\dTWRZP/YMWDHMS:\+]{3,})|(\[\[REDACTED).*?(\]\])$')
+        if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
+            return regex_candidate
+        return p.toolkit.Invalid("Doesn't match temporal format.")
+    return p.toolkit.Invalid("Can't parse Regex")
 
 
 def release_date_validator(regex_candidate):
-    validator = re.compile(
-        r'^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?'
-        r'|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]'
-        r'\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?|(\[\[REDACTED).*?(\]\])$'
-    )
-    if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
-        return regex_candidate
-    return p.toolkit.Invalid("Doesn't match release date format.")
+    if type(regex_candidate) == str:
+        validator = re.compile(
+            r'^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?'
+            r'|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]'
+            r'\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?|(\[\[REDACTED).*?(\]\])$'
+        )
+        if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
+            return regex_candidate
+        return p.toolkit.Invalid("Doesn't match release date format.")
+    return p.toolkit.Invalid("Can't parse Regex")
 
 
 def accrual_periodicity_validator(regex_candidate):
-    validator = re.compile(
-        r'^([Dd]ecennial)|([Qq]uadrennial)|([Aa]nnual)|([Bb]imonthly)|([Ss]emiweekly)|([Dd]aily)|([Bb]iweekly)'
-        r'|([Ss]emiannual)|([Bb]iennial)|([Tt]riennial)|([Tt]hree times a week)|([Tt]hree times a month)'
-        r'|(Continuously updated)|([Mm]onthly)|([Qq]uarterly)|([Ss]emimonthly)|([Tt]hree times a year)'
-        r'|R\/P(?:(\d+(?:[\.,]\d+)?)Y)?(?:(\d+(?:[\.,]\d+)?)M)?(?:(\d+(?:[\.,]\d+)?)D)?(?:T(?:(\d+(?:[\.,]\d+)'
-        r'?)H)?(?:(\d+(?:[\.,]\d+)?)M)?(?:(\d+(?:[\.,]\d+)?)S)?)?$'  # ISO 8601 duration
-        r'|([Ww]eekly)|([Hh]ourly)|([Cc]ompletely irregular)|([Ii]rregular)|(\[\[REDACTED).*?(\]\])$'
-    )
-    if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
-        return regex_candidate
-    return p.toolkit.Invalid("Doesn't match accrual periodicity format.")
+    if type(regex_candidate) == str:
+        validator = re.compile(
+            r'^([Dd]ecennial)|([Qq]uadrennial)|([Aa]nnual)|([Bb]imonthly)|([Ss]emiweekly)|([Dd]aily)|([Bb]iweekly)'
+            r'|([Ss]emiannual)|([Bb]iennial)|([Tt]riennial)|([Tt]hree times a week)|([Tt]hree times a month)'
+            r'|(Continuously updated)|([Mm]onthly)|([Qq]uarterly)|([Ss]emimonthly)|([Tt]hree times a year)'
+            r'|R\/P(?:(\d+(?:[\.,]\d+)?)Y)?(?:(\d+(?:[\.,]\d+)?)M)?(?:(\d+(?:[\.,]\d+)?)D)?(?:T(?:(\d+(?:[\.,]\d+)'
+            r'?)H)?(?:(\d+(?:[\.,]\d+)?)M)?(?:(\d+(?:[\.,]\d+)?)S)?)?$'  # ISO 8601 duration
+            r'|([Ww]eekly)|([Hh]ourly)|([Cc]ompletely irregular)|([Ii]rregular)|(\[\[REDACTED).*?(\]\])$'
+        )
+        if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
+            return regex_candidate
+        return p.toolkit.Invalid("Doesn't match accrual periodicity format.")
+    return p.toolkit.Invalid("Can't parse Regex")
 
 
 def language_validator(regex_candidate):
-    validator = re.compile(
-        r'^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?'
-        r'(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z]'
-        r'(-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed'
-        r'|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu'
-        r'|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min'
-        r'|zh-min-nan|zh-xiang)))$'
-    )
-    if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
-        return regex_candidate
-    return p.toolkit.Invalid("Doesn't match language format.")
+    if type(regex_candidate) == str:
+        validator = re.compile(
+            r'^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?'
+            r'(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z]'
+            r'(-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed'
+            r'|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu'
+            r'|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min'
+            r'|zh-min-nan|zh-xiang)))$'
+        )
+        if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
+            return regex_candidate
+        return p.toolkit.Invalid("Doesn't match language format.")
+    return p.toolkit.Invalid("Can't parse Regex")
 
 
 def primary_it_investment_uii_validator(regex_candidate):
-    validator = re.compile(r'^([0-9]{3}-[0-9]{9})|(\[\[REDACTED).*?(\]\])$')
-    if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
-        return regex_candidate
-    return p.toolkit.Invalid("Doesn't match primary it investment uii format.")
+    if type(regex_candidate) == str:
+        validator = re.compile(r'^([0-9]{3}-[0-9]{9})|(\[\[REDACTED).*?(\]\])$')
+        if isinstance(validator.match(regex_candidate), type(re.match("", ""))):
+            return regex_candidate
+        return p.toolkit.Invalid("Doesn't match primary it investment uii format.")
+    return p.toolkit.Invalid("Can't parse Regex")
 
 
 def string_length_validator(max=100):

--- a/ckanext/usmetadata/plugin/helper.py
+++ b/ckanext/usmetadata/plugin/helper.py
@@ -112,31 +112,31 @@ required_metadata = (
     # TODO should this unique_id be validated against any other unique IDs for this agency?
     {'id': 'unique_id', 'validators': [p.toolkit.get_validator('not_empty'), str, string_length_validator(max=100)]},
     {'id': 'modified', 'validators': [p.toolkit.get_validator('not_empty'), str, string_length_validator(max=100)]},
-    {'id': 'public_access_level', 'validators': [public_access_level_validator]},
-    {'id': 'bureau_code', 'validators': [bureau_code_validator, string_length_validator(max=2100)]},
-    {'id': 'program_code', 'validators': [program_code_validator, string_length_validator(max=2100)]}
+    {'id': 'public_access_level', 'validators': [str, public_access_level_validator]},
+    {'id': 'bureau_code', 'validators': [str, bureau_code_validator, string_length_validator(max=2100)]},
+    {'id': 'program_code', 'validators': [str, program_code_validator, string_length_validator(max=2100)]}
 )
 
 
 # used to bypass validation on create
 required_metadata_update = (
-    {'id': 'public_access_level', 'validators': [public_access_level_validator]},
+    {'id': 'public_access_level', 'validators': [str, public_access_level_validator]},
     {'id': 'publisher', 'validators': [string_length_validator(max=300)]},
     {'id': 'contact_name', 'validators': [string_length_validator(max=300)]},
     {'id': 'contact_email', 'validators': [string_length_validator(max=200)]},
     # TODO should this unique_id be validated against any other unique IDs for this agency?
     {'id': 'unique_id', 'validators': [string_length_validator(max=100)]},
     {'id': 'modified', 'validators': [string_length_validator(max=100)]},
-    {'id': 'bureau_code', 'validators': [bureau_code_validator]},
-    {'id': 'program_code', 'validators': [program_code_validator]}
+    {'id': 'bureau_code', 'validators': [str, bureau_code_validator]},
+    {'id': 'program_code', 'validators': [str, program_code_validator]}
 )
 
 # some of these could be excluded (e.g. related_documents) which can be captured from other ckan default data
 expanded_metadata = (
     # issued
-    {'id': 'release_date', 'validators': [release_date_validator]},
-    {'id': 'accrual_periodicity', 'validators': [accrual_periodicity_validator]},
-    {'id': 'language', 'validators': [language_validator]},
+    {'id': 'release_date', 'validators': [str, release_date_validator]},
+    {'id': 'accrual_periodicity', 'validators': [str, accrual_periodicity_validator]},
+    {'id': 'language', 'validators': [str, language_validator]},
     {'id': 'data_quality', 'validators': [string_length_validator(max=1000)]},
     {'id': 'publishing_status', 'validators': [string_length_validator(max=1000)]},
     {'id': 'is_parent', 'validators': [string_length_validator(max=1000)]},


### PR DESCRIPTION
While rewriting the validation schema for the py3 upgrade, [this bug](https://github.com/GSA/datagov-deploy/issues/3371) was found.  The solution was to simply cast any input to a string before sending to regex expressions.

The cast to `str` was used in other places and does not give any specific error.  The following code snippet illustrates the old behavior followed by the new behavior,
```
~/ckanext-usmetadata$ python
Python 2.7.18 (default, Mar  8 2021, 13:02:45)
[GCC 9.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> validator = re.compile(r'^\d{3}:\d{2}(\s*,\s*\d{3}:\d{2}\s*)*$')
>>> regex_candidate = None
>>> isinstance(validator.match(regex_candidate), type(re.match("", "")))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: expected string or buffer
>>> from builtins import str
>>> regex_candidate = str(None)
>>> isinstance(validator.match(regex_candidate), type(re.match("", "")))
False
>>>
>>> type(regex_candidate)
<class 'future.types.newstr.newstr'>
```