### PR TITLE
usmetadata_filter expects a string; some bool value breaks it

### DIFF
--- a/ckanext/usmetadata/templates/templates_new/package/resource_read.html
+++ b/ckanext/usmetadata/templates/templates_new/package/resource_read.html
@@ -120,7 +120,7 @@
                         </th>
                         <td>
                             {{ h.resource_redacted_icon(c.package,res,key)|safe }}
-                            <span class="redacted-md">{{ h.usmetadata_filter(value) }}</span>
+                            <span class="redacted-md">{{ h.usmetadata_filter(value|string) }}</span>
                         </td>
                     </tr>
                   {% else %}
@@ -128,7 +128,7 @@
                         <th scope="row">{{ key }}</th>
                         <td>
                             {{ h.resource_redacted_icon(c.package,res,key)|safe }}
-                            <span class="redacted-md">{{ h.usmetadata_filter(value) }}</span>
+                            <span class="redacted-md">{{ h.usmetadata_filter(value|string) }}</span>
                         </td>
                     </tr>
                   {% endif %}


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/3598.

This fix makes sure some bool value such as `True` are converted to `'True'` so that `usmetadata_filter` wont generate a 500 error.