### PR TITLE
Bump pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-usmetadata',
-    version='0.2.3',
+    version='0.2.4',
     description='US Metadata Plugin for CKAN',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
For some reason, the pypi version in code was out of date... https://pypi.org/project/ckanext-usmetadata/0.2.3/#history