### PR TITLE
Remove all references to jQuery

### DIFF
--- a/ckanext/usmetadata/fanstatic/dataset_url.js
+++ b/ckanext/usmetadata/fanstatic/dataset_url.js
@@ -1,4 +1,4 @@
-this.ckan.module('usmetadata-slug-preview-slug', function (jQuery, _) {
+this.ckan.module('usmetadata-slug-preview-slug', function (_) {
     return {
         options: {
             prefix: '',
@@ -43,20 +43,6 @@ this.ckan.module('usmetadata-slug-preview-slug', function (jQuery, _) {
                 });
 
                 sandbox.publish('slug-preview-created', preview[0]);
-
-                // Horrible hack to make sure that IE7 rerenders the subsequent
-                // DOM children correctly now that we've render the slug preview element
-                // We should drop this horrible hack ASAP
-                if (jQuery('html').hasClass('ie7')) {
-                    jQuery('.btn').on('click', preview, function () {
-                        jQuery('.controls').ie7redraw();
-                    });
-                    preview.hide();
-                    setTimeout(function () {
-                        preview.show();
-                        jQuery('.controls').ie7redraw();
-                    }, 10);
-                }
             }
 
             // Watch for updates to the target field and update the hidden slug field
@@ -64,16 +50,6 @@ this.ckan.module('usmetadata-slug-preview-slug', function (jQuery, _) {
             sandbox.subscribe('slug-target-changed', function (value) {
                 slug.val(value).trigger('change');
             });
-            //Hiding preview - Issue # 71
-            if (jQuery("#dataset_status_id").val() !== 'draft') {
-                preview.hide();
-            }
         }
     };
 });
-
-//Bug fix Github # 166
-//Inventory_user is navigated to the Error 404 page_when last breadcrumb is selected on the resource uplaod page in IE.
-window.onload = function () {
-    jQuery("#content .toolbar .breadcrumb .active a").prop("href", document.URL)
-};

--- a/ckanext/usmetadata/templates/base.html
+++ b/ckanext/usmetadata/templates/base.html
@@ -8,6 +8,5 @@
      was registered with when the toolkit.add_resource() function was called.
      'example_theme.css' is the path to the CSS file, relative to the root of
      the fanstatic directory. #}
-  {% asset 'base/vendor/jquery.js' %}
   {% asset 'usmetadata/js' %}
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-usmetadata',
-    version='0.2.5',
+    version='0.2.6',
     description='US Metadata Plugin for CKAN',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4262


Notes:
- Since our migration to CKAN 2.9, jQuery has been missing/broken, so remove all customizations that needed jQuery