### PR TITLE
no popular views for inventory

### DIFF
--- a/ckanext/usmetadata/templates/package/snippets/resource_item.html
+++ b/ckanext/usmetadata/templates/package/snippets/resource_item.html
@@ -14,7 +14,6 @@
           </span>
       </div>
       <span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ res.format }}</span>
-    {{ h.popular('views', res.tracking_summary.total, min=10) }}
   </a>
   {% endblock %}
   <p class="description">

--- a/ckanext/usmetadata/templates/snippets/package_item.html
+++ b/ckanext/usmetadata/templates/snippets/package_item.html
@@ -35,11 +35,7 @@
             {% elif package.get('state', '').startswith('deleted') %}
                 <span class="label label-important">{{ _('Deleted') }}</span>
             {% endif %}
-            {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
         </h3>
-        {%- if banner -%}
-        <span class="banner">{{ _('Popular') }}</span>
-        {% endif %}
         {%- if notes -%}
         {{ h.redacted_icon(package, 'notes')|safe }}
         <div class="redacted-md">{{ notes|urlize }}</div>

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-usmetadata',
-    version='0.3.2',
+    version='0.3.3',
     description='US Metadata Plugin for CKAN',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
No need popular views. this will make it easier for ckan core 2.11 upgrade.